### PR TITLE
Add template.html to data package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     license="GNU General Public License v3",
     long_description=readme,
     include_package_data=True,
+    package_data={'': ['template.html']},
     keywords='depx',
     name='depx',
     packages=find_packages(include=['depx']),


### PR DESCRIPTION
This fixes a bug when using depx as a pip-installable tool (the HTML would be missing when installed via pip), e.g.:

```
$ depx ~/Dropbox/Projects/perfil/perfil --format html
Traceback (most recent call last):
  File "/Users/cuducos/.virtualenvs/tmp-e987a6e77c9fa34/bin/depx", line 11, in <module>
    load_entry_point('depx', 'console_scripts', 'depx')()
  File "/Users/cuducos/.virtualenvs/tmp-e987a6e77c9fa34/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/cuducos/.virtualenvs/tmp-e987a6e77c9fa34/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/cuducos/.virtualenvs/tmp-e987a6e77c9fa34/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/cuducos/.virtualenvs/tmp-e987a6e77c9fa34/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/cuducos/Dropbox/Projects/depx/depx/cli.py", line 43, in main
    click.echo(export_to(graph=graph, path=path, dependencies=deps))
  File "/Users/cuducos/Dropbox/Projects/depx/depx/graph.py", line 25, in to_html
    with open('depx/template.html') as file_:
FileNotFoundError: [Errno 2] No such file or directory: 'depx/template.html'
```