### PR TITLE
HTML Template finder

### DIFF
--- a/depx/graph.py
+++ b/depx/graph.py
@@ -4,6 +4,8 @@ import networkx as nx
 from networkx.readwrite import json_graph
 from networkx.drawing.nx_pydot import to_pydot
 import io
+import sys
+from pathlib import Path
 
 
 def create_graph_from(dependencies):
@@ -19,10 +21,24 @@ def create_graph_from(dependencies):
     return graph
 
 
+def get_html_template():
+    default = Path('depx') / 'template.html'
+    if default.exists():
+        return default
+
+    for path in sys.path:
+        if not path.endswith('site-packages'):  # search only in site-packages
+            continue
+
+        template = Path(path) / default
+        if template.exists():
+            return template
+
+
 def to_html(**kwargs):
     data = json_graph.node_link_data(kwargs['graph'])
 
-    with open('depx/template.html') as file_:
+    with open(get_html_template()) as file_:
         template = Template(file_.read())
         content = template.render(data=data, path=kwargs['path'])
         return content

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     license="GNU General Public License v3",
     long_description=readme,
     include_package_data=True,
+    package_data={'': ['template.html']},
     keywords='depx',
     name='depx',
     packages=find_packages(include=['depx']),


### PR DESCRIPTION
In addition to #22, in order to use depx as a pip-installable, we need to be able to find the `template.html` where ever we are. I drafted a proposal here based on `depx/template.html` as the first choice and then inspecting `site-packages`… what do you think about it?

Also, any strategies for tests? Anything better than mocking `sys.path` and `pathlib.Path.exists` method?