### PR TITLE
Fix template.html path

### DIFF
--- a/depx/graph.py
+++ b/depx/graph.py
@@ -7,7 +7,7 @@ import io
 from pathlib import Path
 
 
-TEMPLATE_FILE = Path(__file__).parent.absolute() / 'template.html'
+TEMPLATE_FILE = str(Path(__file__).parent.absolute() / 'template.html')
 
 
 def create_graph_from(dependencies):

--- a/depx/graph.py
+++ b/depx/graph.py
@@ -4,6 +4,10 @@ import networkx as nx
 from networkx.readwrite import json_graph
 from networkx.drawing.nx_pydot import to_pydot
 import io
+from pathlib import Path
+
+
+TEMPLATE_FILE = Path(__file__).parent.absolute() / 'template.html'
 
 
 def create_graph_from(dependencies):
@@ -22,7 +26,7 @@ def create_graph_from(dependencies):
 def to_html(**kwargs):
     data = json_graph.node_link_data(kwargs['graph'])
 
-    with open('depx/template.html') as file_:
+    with open(TEMPLATE_FILE) as file_:
         template = Template(file_.read())
         content = template.render(data=data, path=kwargs['path'])
         return content


### PR DESCRIPTION
Using absolute path to avoid exceptions if use depx in another folder

```
$ depx depx --format html
Traceback (most recent call last):
  File "/usr/local/var/pyenv/versions/depx36/bin/depx", line 9, in <module>
    load_entry_point('depx', 'console_scripts', 'depx')()
  File "/usr/local/var/pyenv/versions/3.6.4/envs/depx36/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/var/pyenv/versions/3.6.4/envs/depx36/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/var/pyenv/versions/3.6.4/envs/depx36/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/var/pyenv/versions/3.6.4/envs/depx36/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/fabio/testing/depx/depx/cli.py", line 43, in main
    click.echo(export_to(graph=graph, path=path, dependencies=deps))
  File "/Users/fabio/testing/depx/depx/graph.py", line 25, in to_html
    with open('depx/template.html') as file_:
FileNotFoundError: [Errno 2] No such file or directory: 'depx/template.html'
````